### PR TITLE
Log errors in the build process

### DIFF
--- a/browser_build.js
+++ b/browser_build.js
@@ -11,5 +11,9 @@ fs.readFile('lib/exec.js', 'utf-8', function (err, data) {
 
     data = data.replace('* mimer', '* mimer - ' + require('./package.json').version);
 
-    fs.writeFile('dist/mimer.js', data.replace('$_MIMER_DATA_LIST', jsonData));
+    fs.writeFile('dist/mimer.js', data.replace('$_MIMER_DATA_LIST', jsonData), function (err) {
+        if (err) {
+            throw err;
+        }
+    });
 });


### PR DESCRIPTION
This makes sure errors are reported in case `writeFile` fails. This will otherwise fail in Node.js 10.x, see https://github.com/nodejs/node/pull/18668.